### PR TITLE
Adding Support For Localization

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,49 @@ An example JSON looks as follows:
 
 The keys `id`, `title` are mandatory and all have to be strings. You can use any value for `status` or `description`.
 
+#### Support For Localization 
+If you are looking to support localization, then you need to add extra optional parameters in your JSON `localizedTitle`, `localizedDescription` and `localizedStatus` like:
+```
+[
+  {
+    "id": "0",
+    "title": "Adding a map",
+    "localizedTitle": [
+      {
+        "language": "ar",
+        "value": "اضافة خارطة"
+      },
+      {
+        "language": "en",
+        "value": "Adding a map"
+      }
+    ],
+    "status": "planned",
+    "localizedStatus": [
+      {
+        "language": "ar",
+        "value": "مجدولة"
+      },
+      {
+        "language": "en",
+        "value": "Planned"
+      }
+    ],
+    "description": "some description",
+    "localizedDescription": [
+      {
+        "language": "ar",
+        "value": "اضافة خارطة لمعرفة الاماكن القريبة"
+      },
+      {
+        "language": "en",
+        "value": "Adding a map to view nearby places"
+      }
+    ]
+  }
+]
+```
+
 ### Add Roadmap using Swift Package Manager
 
 Add `https://github.com/AvdLee/Roadmap.git` within Xcode's package manager.

--- a/Sources/Roadmap/Language.swift
+++ b/Sources/Roadmap/Language.swift
@@ -1,0 +1,23 @@
+//
+//  Language.swift
+//  Roadmap
+//
+//  Created by Abdullah Alhaider on 21/02/2023.
+//
+
+import Foundation
+
+typealias L = Language
+
+enum Language {
+    case LTR, RTL
+    
+    static var code: String {
+        Locale.current.language.languageCode?.identifier.lowercased() ?? "en"
+    }
+    
+    // In case we need some custom UI for lang direction..
+    static var isRTL: Bool {
+        Locale.Language(identifier: code).characterDirection == .rightToLeft
+    }
+}

--- a/Sources/Roadmap/Language.swift
+++ b/Sources/Roadmap/Language.swift
@@ -7,8 +7,6 @@
 
 import Foundation
 
-typealias L = Language
-
 enum Language {
     case LTR, RTL
     

--- a/Sources/Roadmap/Models/RoadmapFeature.swift
+++ b/Sources/Roadmap/Models/RoadmapFeature.swift
@@ -9,25 +9,22 @@ import Foundation
 
 struct RoadmapFeature: Codable, Identifiable {
     let id: String
-    
-    var title: String {
-        localizedTitle.currentLocal ?? originalTitle ?? "N/A"
-    }
-    var description: String? {
-        localizedDescription.currentLocal ?? originalDescription
-    }
-    var status: String? {
-        localizedStatus.currentLocal ?? originalStatus
-    }
-    
-    let originalTitle: String?
-    var originalStatus: String? = nil
-    var originalDescription : String? = nil
-    
+    private let title: String?
+    private var status: String? = nil
+    private var description : String? = nil
     private var localizedTitle: [LocalizedItem]? = nil
     private var localizedStatus: [LocalizedItem]? = nil
     private var localizedDescription: [LocalizedItem]? = nil
     
+    var featureTitle: String {
+        localizedTitle.currentLocal ?? title ?? "N/A"
+    }
+    var featureDescription: String? {
+        localizedDescription.currentLocal ?? description
+    }
+    var featureStatus: String? {
+        localizedStatus.currentLocal ?? status
+    }
     
     var hasVoted: Bool {
         get {
@@ -44,16 +41,6 @@ struct RoadmapFeature: Codable, Identifiable {
             UserDefaults.standard.set(votes, forKey: "roadmap_votes")
         }
     }
-    
-    enum CodingKeys: String, CodingKey {
-        case id
-        case originalTitle = "title"
-        case originalStatus = "status"
-        case originalDescription = "description"
-        case localizedTitle
-        case localizedStatus
-        case localizedDescription
-    }
 }
 
 struct LocalizedItem: Codable {
@@ -63,12 +50,12 @@ struct LocalizedItem: Codable {
 
 extension [LocalizedItem]? {
     var currentLocal: String? {
-        self?.first(where: { $0.language == L.code })?.value
+        self?.first(where: { $0.language == Language.code })?.value
     }
 }
 
 extension RoadmapFeature {
     static func sample() -> RoadmapFeature {
-        .init(id: UUID().uuidString, originalTitle: "WatchOS Support", originalStatus: "Backlog")
+        .init(id: UUID().uuidString, title: "WatchOS Support", status: "Backlog")
     }
 }

--- a/Sources/Roadmap/Models/RoadmapFeature.swift
+++ b/Sources/Roadmap/Models/RoadmapFeature.swift
@@ -9,9 +9,27 @@ import Foundation
 
 struct RoadmapFeature: Codable, Identifiable {
     let id: String
-    let title: String
-    var status: String? = nil
-    var description : String? = nil
+    
+    var title: String {
+        localizedTitle?.first(where: { $0.language == L.code })?.value ?? originalTitle
+    }
+    
+    var description: String? {
+        localizedDescription?.first(where: { $0.language == L.code })?.value ?? originalDescription
+    }
+    
+    var status: String? {
+        localizedStatus?.first(where: { $0.language == L.code })?.value ?? originalStatus
+    }
+    
+    let originalTitle: String
+    var originalStatus: String? = nil
+    var originalDescription : String? = nil
+    
+    private var localizedTitle: [LocalizedItem]? = nil
+    private var localizedStatus: [LocalizedItem]? = nil
+    private var localizedDescription: [LocalizedItem]? = nil
+    
     
     var hasVoted: Bool {
         get {
@@ -28,10 +46,25 @@ struct RoadmapFeature: Codable, Identifiable {
             UserDefaults.standard.set(votes, forKey: "roadmap_votes")
         }
     }
+    
+    enum CodingKeys: String, CodingKey {
+        case id
+        case originalTitle = "title"
+        case originalStatus = "status"
+        case originalDescription = "description"
+        case localizedTitle
+        case localizedStatus
+        case localizedDescription
+    }
+}
+
+struct LocalizedItem: Codable {
+    let language: String
+    let value: String
 }
 
 extension RoadmapFeature {
     static func sample() -> RoadmapFeature {
-        .init(id: UUID().uuidString, title: "WatchOS Support", status: "Backlog")
+        .init(id: UUID().uuidString, originalTitle: "WatchOS Support", originalStatus: "Backlog")
     }
 }

--- a/Sources/Roadmap/Models/RoadmapFeature.swift
+++ b/Sources/Roadmap/Models/RoadmapFeature.swift
@@ -11,7 +11,7 @@ struct RoadmapFeature: Codable, Identifiable {
     let id: String
     
     var title: String {
-        localizedTitle.currentLocal ?? originalTitle
+        localizedTitle.currentLocal ?? originalTitle ?? "N/A"
     }
     var description: String? {
         localizedDescription.currentLocal ?? originalDescription
@@ -20,7 +20,7 @@ struct RoadmapFeature: Codable, Identifiable {
         localizedStatus.currentLocal ?? originalStatus
     }
     
-    let originalTitle: String
+    let originalTitle: String?
     var originalStatus: String? = nil
     var originalDescription : String? = nil
     

--- a/Sources/Roadmap/Models/RoadmapFeature.swift
+++ b/Sources/Roadmap/Models/RoadmapFeature.swift
@@ -11,15 +11,13 @@ struct RoadmapFeature: Codable, Identifiable {
     let id: String
     
     var title: String {
-        localizedTitle?.first(where: { $0.language == L.code })?.value ?? originalTitle
+        localizedTitle.currentLocal ?? originalTitle
     }
-    
     var description: String? {
-        localizedDescription?.first(where: { $0.language == L.code })?.value ?? originalDescription
+        localizedDescription.currentLocal ?? originalDescription
     }
-    
     var status: String? {
-        localizedStatus?.first(where: { $0.language == L.code })?.value ?? originalStatus
+        localizedStatus.currentLocal ?? originalStatus
     }
     
     let originalTitle: String
@@ -61,6 +59,12 @@ struct RoadmapFeature: Codable, Identifiable {
 struct LocalizedItem: Codable {
     let language: String
     let value: String
+}
+
+extension [LocalizedItem]? {
+    var currentLocal: String? {
+        self?.first(where: { $0.language == L.code })?.value
+    }
 }
 
 extension RoadmapFeature {

--- a/Sources/Roadmap/RoadmapFeatureView.swift
+++ b/Sources/Roadmap/RoadmapFeatureView.swift
@@ -30,16 +30,16 @@ struct RoadmapFeatureView: View {
     var horizontalCell : some View {
         HStack {
             VStack(alignment: .leading, spacing: 8) {
-                Text(viewModel.feature.title)
+                Text(viewModel.feature.featureTitle)
                     .font(viewModel.configuration.style.titleFont)
                 
-                if let description = viewModel.feature.description {
+                if let description = viewModel.feature.featureDescription {
                     Text(description)
                         .font(viewModel.configuration.style.numberFont)
                         .foregroundColor(Color.secondary)
                 }
 
-                if let status = viewModel.feature.status {
+                if let status = viewModel.feature.featureStatus {
                         Text(status)
                             .padding(6)
                             .background(Color.primary.opacity(0.05))
@@ -65,16 +65,16 @@ struct RoadmapFeatureView: View {
             }
             
             VStack(alignment: .leading, spacing: 8) {
-                Text(viewModel.feature.title)
+                Text(viewModel.feature.featureTitle)
                     .font(viewModel.configuration.style.titleFont)
                 
-                if let description = viewModel.feature.description {
+                if let description = viewModel.feature.featureDescription {
                     Text(description)
                         .font(viewModel.configuration.style.numberFont)
                         .foregroundColor(Color.secondary)
                 }
 
-                if let status = viewModel.feature.status {
+                if let status = viewModel.feature.featureStatus {
                         Text(status)
                             .padding(6)
                             .background(Color.primary.opacity(0.05))

--- a/Sources/Roadmap/RoadmapVoteButton.swift
+++ b/Sources/Roadmap/RoadmapVoteButton.swift
@@ -99,8 +99,8 @@ struct RoadmapVoteButton : View {
                 hasVoted = viewModel.feature.hasVoted
             }
         }
-        .accessibilityHint(Text("Vote for \(viewModel.feature.title)"))
-        .help("Vote for \(viewModel.feature.title)")
+        .accessibilityHint(Text("Vote for \(viewModel.feature.featureTitle)"))
+        .help("Vote for \(viewModel.feature.featureTitle)")
         .animateAccessible()
         .accessibilityShowsLargeContentViewer()
     }


### PR DESCRIPTION
This changes will add support for localization where we just need to add extra optional parameters in our json:
`localizedTitle`, `localizedDescription` and `localizedStatus`
If one of the above is `nil` then we will look into the original values to use them `title`, `description` and `status`

If you are going to send always the localized values `localizedTitle`, `localizedDescription` and `localizedStatus`, then no need to return the original values `title`, `description` and `status`

```
[
  {
    "id": "0",
    "title": "Adding a map",
    "localizedTitle": [
      {
        "language": "ar",
        "value": "اضافة خارطة"
      },
      {
        "language": "en",
        "value": "Adding a map"
      }
    ],
    "status": "planned",
    "localizedStatus": [
      {
        "language": "ar",
        "value": "مجدولة"
      },
      {
        "language": "en",
        "value": "Planned"
      }
    ],
    "description": "some description",
    "localizedDescription": [
      {
        "language": "ar",
        "value": "اضافة خارطة لمعرفة الاماكن القريبة"
      },
      {
        "language": "en",
        "value": "Adding a map to view nearby places"
      }
    ]
  }
]
```