### PR TITLE
Adds ability to customise status views tint color.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ public struct RoadmapStyle {
     /// The font used for the status views
     let statusFont : Font
     
+    /// The tint color of the status view
+    let statusTintColor: (String) -> Color
+    
     /// The corner radius for the upvote button
     let radius : CGFloat
     
@@ -96,6 +99,7 @@ public struct RoadmapStyle {
                 titleFont: Font,
                 numberFont: Font,
                 statusFont: Font,
+                statusTintColor: @escaping (String) -> Color = { _ in Color.primary },
                 cornerRadius: CGFloat,
                 cellColor: Color = Color.defaultCellColor,
                 selectedColor: Color = .white,
@@ -105,6 +109,7 @@ public struct RoadmapStyle {
         self.titleFont = titleFont
         self.numberFont = numberFont
         self.statusFont = statusFont
+        self.statusTintColor = statusTintColor
         self.radius = cornerRadius
         self.cellColor = cellColor
         self.selectedForegroundColor = selectedColor

--- a/Sources/Roadmap/RoadmapFeatureView.swift
+++ b/Sources/Roadmap/RoadmapFeatureView.swift
@@ -42,8 +42,8 @@ struct RoadmapFeatureView: View {
                 if let status = viewModel.feature.status {
                         Text(status)
                             .padding(6)
-                            .background(Color.primary.opacity(0.05))
-                            .foregroundColor(Color.primary.opacity(0.75))
+                            .background(viewModel.configuration.style.statusTintColor(status).opacity(0.05))
+                            .foregroundColor(viewModel.configuration.style.statusTintColor(status).opacity(0.75))
                             .cornerRadius(5)
                             .font(viewModel.configuration.style.statusFont)
                 }
@@ -77,8 +77,8 @@ struct RoadmapFeatureView: View {
                 if let status = viewModel.feature.status {
                         Text(status)
                             .padding(6)
-                            .background(Color.primary.opacity(0.05))
-                            .foregroundColor(Color.primary.opacity(0.75))
+                            .background(viewModel.configuration.style.statusTintColor(status).opacity(0.05))
+                            .foregroundColor(viewModel.configuration.style.statusTintColor(status).opacity(0.75))
                             .cornerRadius(5)
                             .font(viewModel.configuration.style.statusFont)
                 }

--- a/Sources/Roadmap/Styling/RoadmapStyle.swift
+++ b/Sources/Roadmap/Styling/RoadmapStyle.swift
@@ -39,7 +39,7 @@ public struct RoadmapStyle {
                 titleFont: Font,
                 numberFont: Font,
                 statusFont: Font,
-                statusTintColor: @escaping (String) -> Color,
+                statusTintColor: @escaping (String) -> Color = { _ in Color.primary },
                 cornerRadius: CGFloat,
                 cellColor: Color = Color.defaultCellColor,
                 selectedColor: Color = .white,

--- a/Sources/Roadmap/Styling/RoadmapStyle.swift
+++ b/Sources/Roadmap/Styling/RoadmapStyle.swift
@@ -20,6 +20,9 @@ public struct RoadmapStyle {
     /// The font used for the status views
     public var statusFont : Font
     
+    /// The tint color of the status view
+    public var statusTintColor: (String) -> Color
+    
     /// The corner radius for the upvote button
     public var radius : CGFloat
     
@@ -36,6 +39,7 @@ public struct RoadmapStyle {
                 titleFont: Font,
                 numberFont: Font,
                 statusFont: Font,
+                statusTintColor: @escaping (String) -> Color,
                 cornerRadius: CGFloat,
                 cellColor: Color = Color.defaultCellColor,
                 selectedColor: Color = .white,
@@ -45,6 +49,7 @@ public struct RoadmapStyle {
         self.titleFont = titleFont
         self.numberFont = numberFont
         self.statusFont = statusFont
+        self.statusTintColor = statusTintColor
         self.radius = cornerRadius
         self.cellColor = cellColor
         self.selectedForegroundColor = selectedColor

--- a/Sources/Roadmap/Styling/RoadmapTemplates.swift
+++ b/Sources/Roadmap/Styling/RoadmapTemplates.swift
@@ -19,28 +19,24 @@ public enum RoadmapTemplate : CaseIterable {
                                 titleFont: self.titleFont,
                                 numberFont: self.numberFont,
                                 statusFont: self.captionFont,
-                                statusTintColor: self.statusTintColor,
                                 cornerRadius: 10)
         case .playful:
             return RoadmapStyle(icon: Image(systemName: "arrow.up"),
                                 titleFont: self.titleFont,
                                 numberFont: self.numberFont,
                                 statusFont: self.captionFont,
-                                statusTintColor: self.statusTintColor,
                                 cornerRadius: 15)
         case .classy:
             return RoadmapStyle(icon: Image(systemName: "chevron.up"),
                                 titleFont: self.titleFont,
                                 numberFont: self.numberFont,
                                 statusFont: self.captionFont,
-                                statusTintColor: self.statusTintColor,
                                 cornerRadius: 5)
         case .technical:
             return RoadmapStyle(icon: Image(systemName: "chevron.up"),
                                 titleFont: self.titleFont,
                                 numberFont: self.numberFont,
                                 statusFont: self.captionFont,
-                                statusTintColor: self.statusTintColor,
                                 cornerRadius: 2)
         }
     }
@@ -92,9 +88,5 @@ public enum RoadmapTemplate : CaseIterable {
         #else
             return Font.system(.caption, design: self.fontDesign, weight: .bold)
         #endif
-    }
-    
-    var statusTintColor: (String) -> Color {
-        { _ in Color.primary }
     }
 }

--- a/Sources/Roadmap/Styling/RoadmapTemplates.swift
+++ b/Sources/Roadmap/Styling/RoadmapTemplates.swift
@@ -19,24 +19,28 @@ public enum RoadmapTemplate : CaseIterable {
                                 titleFont: self.titleFont,
                                 numberFont: self.numberFont,
                                 statusFont: self.captionFont,
+                                statusTintColor: self.statusTintColor,
                                 cornerRadius: 10)
         case .playful:
             return RoadmapStyle(icon: Image(systemName: "arrow.up"),
                                 titleFont: self.titleFont,
                                 numberFont: self.numberFont,
                                 statusFont: self.captionFont,
+                                statusTintColor: self.statusTintColor,
                                 cornerRadius: 15)
         case .classy:
             return RoadmapStyle(icon: Image(systemName: "chevron.up"),
                                 titleFont: self.titleFont,
                                 numberFont: self.numberFont,
                                 statusFont: self.captionFont,
+                                statusTintColor: self.statusTintColor,
                                 cornerRadius: 5)
         case .technical:
             return RoadmapStyle(icon: Image(systemName: "chevron.up"),
                                 titleFont: self.titleFont,
                                 numberFont: self.numberFont,
                                 statusFont: self.captionFont,
+                                statusTintColor: self.statusTintColor,
                                 cornerRadius: 2)
         }
     }
@@ -88,5 +92,9 @@ public enum RoadmapTemplate : CaseIterable {
         #else
             return Font.system(.caption, design: self.fontDesign, weight: .bold)
         #endif
+    }
+    
+    var statusTintColor: (String) -> Color {
+        { _ in Color.primary }
     }
 }


### PR DESCRIPTION
This PR aims to let you customise tint color to status views.

The implementation is inspired from #11. I have added a closure of type ```(String) -> Color``` in ```RoadmapStyle```. The default value is ```Color.primary```.

Fixes #11 