### PR TITLE
Adds support to mark features as finished.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ An example JSON looks as follows:
         "id": "1",
         "title": "Combine sentences",
         "status": "planned",
-        "description" : "You can add a little bit of extra context here."
+        "description" : "You can add a little bit of extra context here.",
+        "isFinished": true
     },
     {
         "id": "2",
@@ -73,6 +74,9 @@ If you are looking to support localization, then you need to add extra optional 
   }
 ]
 ```
+
+#### Keep a list of finished features
+If you send `isFinished` as `true`, then the voting view will be hidden for the users & no API call will be made to fetch votes. This is an optional value and it's default value is `false`.
 
 ### Add Roadmap using Swift Package Manager
 

--- a/README.md
+++ b/README.md
@@ -20,12 +20,19 @@ An example JSON looks as follows:
         "title": "Combine sentences",
         "status": "planned",
         "description" : "You can add a little bit of extra context here.",
-        "isFinished": true
+        "isFinished": false
     },
     {
         "id": "2",
         "title": "Open with Finder support",
         "status": "planned"
+    },
+    {
+        "id": "3",
+        "title": "Initial Launch",
+        "status": "finished",
+        "description" : "Release v1 to the public.",
+        "isFinished": true
     }
 ]
 ```

--- a/Sources/Roadmap/DataProviders/FeatureVoter.swift
+++ b/Sources/Roadmap/DataProviders/FeatureVoter.swift
@@ -14,6 +14,10 @@ struct FeatureVoter {
     /// Votes for the given feature.
     /// - Returns: The new `count` if successful.
     func vote() async -> Int? {
+        guard feature.hasNotFinished else {
+            return nil
+        }
+        
         do {
             let urlString = "https://api.countapi.xyz/hit/\(namespace)/feature\(feature.id)"
             let count: RoadmapFeatureVotingCount = try await JSONDataFetcher.loadJSON(fromURLString: urlString)

--- a/Sources/Roadmap/DataProviders/FeatureVotingCountFetcher.swift
+++ b/Sources/Roadmap/DataProviders/FeatureVotingCountFetcher.swift
@@ -12,6 +12,10 @@ struct FeatureVotingCountFetcher {
     let namespace: String
 
     func fetch() async -> Int {
+        guard feature.hasNotFinished else {
+            return 0
+        }
+        
         do {
             let urlString = "https://api.countapi.xyz/get/\(namespace)/feature\(feature.id)"
             let count: RoadmapFeatureVotingCount = try await JSONDataFetcher.loadJSON(fromURLString: urlString)

--- a/Sources/Roadmap/Models/RoadmapFeature.swift
+++ b/Sources/Roadmap/Models/RoadmapFeature.swift
@@ -26,6 +26,8 @@ struct RoadmapFeature: Codable, Identifiable {
         localizedStatus.currentLocal ?? status
     }
     
+    var isFinished: Bool? = nil
+    
     var hasVoted: Bool {
         get {
             guard let votes = UserDefaults.standard.array(forKey: "roadmap_votes") as? [String] else { return false }
@@ -40,6 +42,10 @@ struct RoadmapFeature: Codable, Identifiable {
             }
             UserDefaults.standard.set(votes, forKey: "roadmap_votes")
         }
+    }
+    
+    var hasNotFinished: Bool {
+        !(isFinished ?? false)
     }
 }
 

--- a/Sources/Roadmap/RoadmapFeatureView.swift
+++ b/Sources/Roadmap/RoadmapFeatureView.swift
@@ -48,25 +48,34 @@ struct RoadmapFeatureView: View {
                             .font(viewModel.configuration.style.statusFont)
                 }
             }
-            .padding(.top, 4)
-
+            
             Spacer()
             
-            RoadmapVoteButton(viewModel: viewModel)
+            if viewModel.feature.hasNotFinished {
+                RoadmapVoteButton(viewModel: viewModel)
+            }
         }
         .padding()
     }
     
     var verticalCell : some View {
         VStack(alignment: .leading, spacing: 16) {
-            HStack {
-                RoadmapVoteButton(viewModel: viewModel)
-                Spacer()
+            if viewModel.feature.hasNotFinished {
+                HStack {
+                    RoadmapVoteButton(viewModel: viewModel)
+                    Spacer()
+                }
             }
             
             VStack(alignment: .leading, spacing: 8) {
-                Text(viewModel.feature.featureTitle)
-                    .font(viewModel.configuration.style.titleFont)
+                HStack {
+                    Text(viewModel.feature.featureTitle)
+                        .font(viewModel.configuration.style.titleFont)
+                    
+                    if !viewModel.feature.hasNotFinished {
+                        Spacer()
+                    }
+                }
                 
                 if let description = viewModel.feature.featureDescription {
                     Text(description)


### PR DESCRIPTION
If `isFinished` is coming as `true` in the response, the vote view will be hidden & no API call will be made to fetch the vote count. The default value is `false`.

Fixes #36