### PR TITLE
Allow and disallow voting based on boolean

### DIFF
--- a/Sources/Roadmap/DataProviders/FeatureVotingCountFetcher.swift
+++ b/Sources/Roadmap/DataProviders/FeatureVotingCountFetcher.swift
@@ -17,6 +17,7 @@ struct FeatureVotingCountFetcher {
             let count: RoadmapFeatureVotingCount = try await JSONDataFetcher.loadJSON(fromURLString: urlString)
             return count.value ?? 0
         } catch {
+            print(error)
             print("Fetching voting count failed with error: \(error.localizedDescription)")
             return 0
         }

--- a/Sources/Roadmap/RoadmapConfiguration.swift
+++ b/Sources/Roadmap/RoadmapConfiguration.swift
@@ -22,6 +22,9 @@ public struct RoadmapConfiguration {
     
     /// Set this to true to have a different order of features everytime the view is presented
     public let shuffledOrder: Bool
+    
+    /// Set this to true to if you want to let users vote. Set it to false for read-only mode. This can be used to only let paying users vote for example.
+    public let allowVotes: Bool
 
     /// Creates a new Roadmap configuration instance.
     /// - Parameters:
@@ -30,7 +33,7 @@ public struct RoadmapConfiguration {
     ///   See `https://countapi.xyz/` for more information.
     ///   Defaults to your main bundle identifier.
     ///   - style: Pick a `RoadmapStyle` that fits your app best. By default the `.standard` option is used.
-    public init(roadmapJSONURL: URL, namespace: String? = nil, style: RoadmapStyle = RoadmapTemplate.standard.style, shuffledOrder: Bool = false) {
+    public init(roadmapJSONURL: URL, namespace: String? = nil, style: RoadmapStyle = RoadmapTemplate.standard.style, shuffledOrder: Bool = false, allowVotes: Bool = true) {
         guard let namespace = namespace ?? Bundle.main.bundleIdentifier else {
             fatalError("Missing namespace")
         }
@@ -39,6 +42,7 @@ public struct RoadmapConfiguration {
         self.namespace = namespace
         self.style = style
         self.shuffledOrder = shuffledOrder
+        self.allowVotes = allowVotes
     }
 }
 

--- a/Sources/Roadmap/RoadmapFeatureViewModel.swift
+++ b/Sources/Roadmap/RoadmapFeatureViewModel.swift
@@ -11,12 +11,16 @@ import SwiftUI
 final class RoadmapFeatureViewModel: ObservableObject {
     let feature: RoadmapFeature
     let configuration: RoadmapConfiguration
+    let canVote: Bool
 
     @Published var voteCount = 0
+    
 
     init(feature: RoadmapFeature, configuration: RoadmapConfiguration) {
         self.feature = feature
         self.configuration = configuration
+        
+        self.canVote = configuration.allowVotes
     }
     
     @MainActor

--- a/Sources/Roadmap/RoadmapView.swift
+++ b/Sources/Roadmap/RoadmapView.swift
@@ -15,68 +15,33 @@ public struct RoadmapView: View {
         #if os(macOS)
         if #available(macOS 13.0, *) {
             List {
-                if viewModel.features.isEmpty {
-                    macLoadingItems
-                } else {
-                    ForEach(viewModel.features) { feature in
-                        RoadmapFeatureView(viewModel: viewModel.featureViewModel(for: feature))
-                            .listRowSeparator(.hidden)
-                    }
+                ForEach(viewModel.features) { feature in
+                    RoadmapFeatureView(viewModel: viewModel.featureViewModel(for: feature))
+                        .listRowSeparator(.hidden)
                 }
             }
             .scrollContentBackground(.hidden)
             .listStyle(.plain)
         } else {
             List {
-                if viewModel.features.isEmpty {
-                    macLoadingItems
-                } else {
-                    ForEach(viewModel.features) { feature in
-                        Section {
-                            RoadmapFeatureView(viewModel: viewModel.featureViewModel(for: feature))
-                        }
+                ForEach(viewModel.features) { feature in
+                    Section {
+                        RoadmapFeatureView(viewModel: viewModel.featureViewModel(for: feature))
                     }
                 }
             }
         }
         #else
         List {
-            if viewModel.features.isEmpty {
-                iOSLoadingItems
-            } else {
-                ForEach(viewModel.features) { feature in
-                    RoadmapFeatureView(viewModel: viewModel.featureViewModel(for: feature))
-                        .listRowSeparator(.hidden)
-                }
+            ForEach(viewModel.features) { feature in
+                RoadmapFeatureView(viewModel: viewModel.featureViewModel(for: feature))
+                    .listRowSeparator(.hidden)
             }
         }
         .scrollContentBackground(.hidden)
         .listStyle(.plain)
         #endif
     }
-    
-    #if os(macOS)
-    var macLoadingItems: some View {
-        ForEach(1...6, id: \.self) { index in
-            if #available(macOS 13.0, *) {
-                RoadmapFeatureView(viewModel: RoadmapFeatureViewModel(feature: .sample(), configuration: .sample()))
-                    .redacted(reason: .placeholder)
-                    .listRowSeparator(.hidden)
-            } else {
-                RoadmapFeatureView(viewModel: RoadmapFeatureViewModel(feature: .sample(), configuration: .sample()))
-                    .redacted(reason: .placeholder)
-            }
-        }
-    }
-    #else
-    var iOSLoadingItems: some View {
-        ForEach(1...6, id: \.self) { index in
-            RoadmapFeatureView(viewModel: RoadmapFeatureViewModel(feature: .sample(), configuration: .sample()))
-                .listRowSeparator(.hidden)
-                .redacted(reason: .placeholder)
-        }
-    }
-    #endif
 
 }
 

--- a/Sources/Roadmap/RoadmapView.swift
+++ b/Sources/Roadmap/RoadmapView.swift
@@ -12,36 +12,72 @@ public struct RoadmapView: View {
     
     public var body: some View {
         
-#if os(macOS)
+        #if os(macOS)
         if #available(macOS 13.0, *) {
             List {
+                if viewModel.features.isEmpty {
+                    macLoadingItems
+                } else {
+                    ForEach(viewModel.features) { feature in
+                        RoadmapFeatureView(viewModel: viewModel.featureViewModel(for: feature))
+                            .listRowSeparator(.hidden)
+                    }
+                }
+            }
+            .scrollContentBackground(.hidden)
+            .listStyle(.plain)
+        } else {
+            List {
+                if viewModel.features.isEmpty {
+                    macLoadingItems
+                } else {
+                    ForEach(viewModel.features) { feature in
+                        Section {
+                            RoadmapFeatureView(viewModel: viewModel.featureViewModel(for: feature))
+                        }
+                    }
+                }
+            }
+        }
+        #else
+        List {
+            if viewModel.features.isEmpty {
+                iOSLoadingItems
+            } else {
                 ForEach(viewModel.features) { feature in
                     RoadmapFeatureView(viewModel: viewModel.featureViewModel(for: feature))
                         .listRowSeparator(.hidden)
                 }
             }
-            .listStyle(.plain)
-        } else {
-            List {
-                ForEach(viewModel.features) { feature in
-                    Section {
-                        RoadmapFeatureView(viewModel: viewModel.featureViewModel(for: feature))
-                    }
-                }
-            }
         }
-#else
-        List {
-            ForEach(viewModel.features) { feature in
-                RoadmapFeatureView(viewModel: viewModel.featureViewModel(for: feature))
-                    .listRowSeparator(.hidden)
-                    .listRowBackground(Color.clear)
-            }
-        }
+        .scrollContentBackground(.hidden)
         .listStyle(.plain)
-#endif
+        #endif
     }
     
+    #if os(macOS)
+    var macLoadingItems: some View {
+        ForEach(1...6, id: \.self) { index in
+            if #available(macOS 13.0, *) {
+                RoadmapFeatureView(viewModel: RoadmapFeatureViewModel(feature: .sample(), configuration: .sample()))
+                    .redacted(reason: .placeholder)
+                    .listRowSeparator(.hidden)
+            } else {
+                RoadmapFeatureView(viewModel: RoadmapFeatureViewModel(feature: .sample(), configuration: .sample()))
+                    .redacted(reason: .placeholder)
+            }
+        }
+    }
+    #else
+    var iOSLoadingItems: some View {
+        ForEach(1...6, id: \.self) { index in
+            RoadmapFeatureView(viewModel: RoadmapFeatureViewModel(feature: .sample(), configuration: .sample()))
+                .listRowSeparator(.hidden)
+                .redacted(reason: .placeholder)
+        }
+    }
+    #endif
+
 }
 
 public extension RoadmapView {

--- a/Sources/Roadmap/RoadmapVoteButton.swift
+++ b/Sources/Roadmap/RoadmapVoteButton.swift
@@ -18,22 +18,26 @@ struct RoadmapVoteButton : View {
     
     var body: some View {
         Button {
-            Task {
-                await viewModel.vote()
-                #if os(iOS)
-                let haptic = UIImpactFeedbackGenerator(style: .soft)
-                haptic.impactOccurred()
-                #endif
+            if viewModel.canVote {
+                Task {
+                    await viewModel.vote()
+                    #if os(iOS)
+                    let haptic = UIImpactFeedbackGenerator(style: .soft)
+                    haptic.impactOccurred()
+                    #endif
+                }
             }
         } label: {
             ZStack {
                 if typeSize.isAccessibilitySize {
                     HStack(spacing: isHovering ? 2 : 0) {
-                        viewModel.configuration.style.upvoteIcon
-                            .foregroundColor(hasVoted ? viewModel.configuration.style.selectedForegroundColor : viewModel.configuration.style.tintColor)
-                            .imageScale(.large)
-                            .font(Font.system(size: 17, weight: .medium))
-                            .frame(maxWidth: 24, maxHeight: 24)
+                        if viewModel.canVote {
+                            viewModel.configuration.style.upvoteIcon
+                                .foregroundColor(hasVoted ? viewModel.configuration.style.selectedForegroundColor : viewModel.configuration.style.tintColor)
+                                .imageScale(.large)
+                                .font(Font.system(size: 17, weight: .medium))
+                                .frame(maxWidth: 24, maxHeight: 24)
+                        }
                         
                         if showNumber {
                             Text("\(viewModel.voteCount)")
@@ -48,12 +52,14 @@ struct RoadmapVoteButton : View {
                     .background(backgroundView)
                 } else {
                     VStack(spacing: isHovering ? 6 : 4) {
-                        viewModel.configuration.style.upvoteIcon
-                            .foregroundColor(hasVoted ? viewModel.configuration.style.selectedForegroundColor : viewModel.configuration.style.tintColor)
-                            .imageScale(.large)
-                            .font(viewModel.configuration.style.numberFont)
-                            .frame(maxWidth: 20, maxHeight: 20)
-                            .minimumScaleFactor(0.75)
+                        if viewModel.canVote {
+                            viewModel.configuration.style.upvoteIcon
+                                .foregroundColor(hasVoted ? viewModel.configuration.style.selectedForegroundColor : viewModel.configuration.style.tintColor)
+                                .imageScale(.large)
+                                .font(viewModel.configuration.style.numberFont)
+                                .frame(maxWidth: 20, maxHeight: 20)
+                                .minimumScaleFactor(0.75)
+                        }
                         
                         if showNumber {
                             Text("\(viewModel.voteCount)")
@@ -86,7 +92,7 @@ struct RoadmapVoteButton : View {
             }
         }
         .onHover { newHover in
-            if !hasVoted {
+            if viewModel.canVote && !hasVoted {
                 withAnimation(.spring(response: 0.4, dampingFraction: 0.7, blendDuration: 0)) {
                     isHovering = newHover
                 }
@@ -98,8 +104,8 @@ struct RoadmapVoteButton : View {
                 hasVoted = viewModel.feature.hasVoted
             }
         }
-        .accessibilityHint(Text("Vote for \(viewModel.feature.featureTitle)"))
-        .help("Vote for \(viewModel.feature.featureTitle)")
+        .accessibilityHint(viewModel.canVote ? Text("Vote for \(viewModel.feature.featureTitle)") : Text(""))
+        .help(viewModel.canVote ? "Vote for \(viewModel.feature.featureTitle)" : "")
         .animateAccessible()
         .accessibilityShowsLargeContentViewer()
     }


### PR DESCRIPTION
Added an option to the configuration which allows developers to only let certain users vote.

This can be useful for only letting paid users vote for example.