### PR TITLE
Allow to configure a header and/or footer

### DIFF
--- a/Example/RoadmapExample/RoadmapExample/ContentView.swift
+++ b/Example/RoadmapExample/RoadmapExample/ContentView.swift
@@ -29,12 +29,13 @@ struct ContentView: View {
             configuration: configuration,
             header: {
                 GroupBox {
-                    Text("These are features that are coming to RocketSim soon. You can vote on the ones you'd love to see me add first. [Let me know](https://github.com/AvdLee/RocketSimApp/issues/new?assignees=AvdLee&labels=enhancement&template=feature_request.md) if you have a suggestion for a feature that needs to be added to this list.")
-                        .lineLimit(2)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .padding(10)
-                }.padding(.horizontal, 20)
-                    .padding(.vertical, 20)
+                    HStack {
+                        Text("You can add a header to introduce your users to your Roadmap.")
+                            .padding(10)
+                        Spacer()
+                    }
+                        .frame(maxWidth: .infinity)
+                }.padding(.vertical, 20)
             }, footer: {
                 HStack {
                     Spacer()

--- a/Example/RoadmapExample/RoadmapExample/ContentView.swift
+++ b/Example/RoadmapExample/RoadmapExample/ContentView.swift
@@ -25,7 +25,23 @@ struct ContentView: View {
     }
 
     private var roadmapView: some View {
-        RoadmapView(configuration: configuration)
+        RoadmapView(
+            configuration: configuration,
+            header: {
+                GroupBox {
+                    Text("These are features that are coming to RocketSim soon. You can vote on the ones you'd love to see me add first. [Let me know](https://github.com/AvdLee/RocketSimApp/issues/new?assignees=AvdLee&labels=enhancement&template=feature_request.md) if you have a suggestion for a feature that needs to be added to this list.")
+                        .lineLimit(2)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding(10)
+                }.padding(.horizontal, 20)
+                    .padding(.vertical, 20)
+            }, footer: {
+                HStack {
+                    Spacer()
+                    Text("Feature Voting with [Roadmap](https://github.com/AvdLee/Roadmap)")
+                    Spacer()
+                }.padding(.vertical, 10)
+            })
             .navigationTitle("Roadmap Example")
             .toolbar {
                 ToolbarItem {

--- a/Sources/Roadmap/RoadmapFeatureView.swift
+++ b/Sources/Roadmap/RoadmapFeatureView.swift
@@ -42,9 +42,13 @@ struct RoadmapFeatureView: View {
                 if let status = viewModel.feature.featureStatus {
                         Text(status)
                             .padding(6)
-                            .background(viewModel.configuration.style.statusTintColor(status).opacity(0.05))
-                            .foregroundColor(viewModel.configuration.style.statusTintColor(status).opacity(0.75))
+                            .background(viewModel.configuration.style.statusTintColor(status).opacity(0.1))
+                            .foregroundColor(viewModel.configuration.style.statusTintColor(status))
                             .cornerRadius(5)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 5)
+                                    .stroke(viewModel.configuration.style.statusTintColor(status).opacity(0.15), lineWidth: 1)
+                            )
                             .font(viewModel.configuration.style.statusFont)
                 }
             }
@@ -77,9 +81,13 @@ struct RoadmapFeatureView: View {
                 if let status = viewModel.feature.featureStatus {
                         Text(status)
                             .padding(6)
-                            .background(viewModel.configuration.style.statusTintColor(status).opacity(0.05))
-                            .foregroundColor(viewModel.configuration.style.statusTintColor(status).opacity(0.75))
+                            .background(viewModel.configuration.style.statusTintColor(status).opacity(0.1))
+                            .foregroundColor(viewModel.configuration.style.statusTintColor(status))
                             .cornerRadius(5)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 5)
+                                    .stroke(viewModel.configuration.style.statusTintColor(status).opacity(0.15), lineWidth: 1)
+                            )
                             .font(viewModel.configuration.style.statusFont)
                 }
             }

--- a/Sources/Roadmap/RoadmapView.swift
+++ b/Sources/Roadmap/RoadmapView.swift
@@ -18,6 +18,7 @@ public struct RoadmapView: View {
                 ForEach(viewModel.features) { feature in
                     RoadmapFeatureView(viewModel: viewModel.featureViewModel(for: feature))
                         .listRowSeparator(.hidden)
+                        .listRowBackground(Color.clear)
                 }
             }
             .listStyle(.plain)

--- a/Sources/Roadmap/RoadmapView.swift
+++ b/Sources/Roadmap/RoadmapView.swift
@@ -17,47 +17,35 @@ public struct RoadmapView<Header: View, Footer: View>: View {
         #if os(macOS)
         if #available(macOS 13.0, *) {
             List {
-                Section {
-                    ForEach(viewModel.features) { feature in
-                        RoadmapFeatureView(viewModel: viewModel.featureViewModel(for: feature))
-                            .listRowSeparator(.hidden)
-                            .listRowBackground(Color.clear)
-                    }
-                } header: {
-                    header
-                } footer: {
-                    footer
+                header
+                ForEach(viewModel.features) { feature in
+                    RoadmapFeatureView(viewModel: viewModel.featureViewModel(for: feature))
+                        .listRowSeparator(.hidden)
+                        .listRowBackground(Color.clear)
                 }
+                footer
             }
             .scrollContentBackground(.hidden)
             .listStyle(.plain)
         } else {
             List {
-                Section {
-                    ForEach(viewModel.features) { feature in
-                        Section {
-                            RoadmapFeatureView(viewModel: viewModel.featureViewModel(for: feature))
-                        }
+                header
+                ForEach(viewModel.features) { feature in
+                    Section {
+                        RoadmapFeatureView(viewModel: viewModel.featureViewModel(for: feature))
                     }
-                } header: {
-                    header
-                } footer: {
-                    footer
                 }
+                footer
             }
         }
         #else
         List {
-            Section {
-                ForEach(viewModel.features) { feature in
-                    RoadmapFeatureView(viewModel: viewModel.featureViewModel(for: feature))
-                        .listRowSeparator(.hidden)
-                }
-            } header: {
-                header
-            } footer: {
-                footer
+            header
+            ForEach(viewModel.features) { feature in
+                RoadmapFeatureView(viewModel: viewModel.featureViewModel(for: feature))
+                    .listRowSeparator(.hidden)
             }
+            footer
         }
         .scrollContentBackground(.hidden)
         .listStyle(.plain)

--- a/Sources/Roadmap/RoadmapView.swift
+++ b/Sources/Roadmap/RoadmapView.swift
@@ -7,36 +7,56 @@
 
 import SwiftUI
 
-public struct RoadmapView: View {
+public struct RoadmapView<Header: View, Footer: View>: View {
     @StateObject var viewModel: RoadmapViewModel
-    
+    let header: Header
+    let footer: Footer
+
     public var body: some View {
         
         #if os(macOS)
         if #available(macOS 13.0, *) {
             List {
-                ForEach(viewModel.features) { feature in
-                    RoadmapFeatureView(viewModel: viewModel.featureViewModel(for: feature))
-                        .listRowSeparator(.hidden)
-                        .listRowBackground(Color.clear)
+                Section {
+                    ForEach(viewModel.features) { feature in
+                        RoadmapFeatureView(viewModel: viewModel.featureViewModel(for: feature))
+                            .listRowSeparator(.hidden)
+                            .listRowBackground(Color.clear)
+                    }
+                } header: {
+                    header
+                } footer: {
+                    footer
                 }
             }
             .scrollContentBackground(.hidden)
             .listStyle(.plain)
         } else {
             List {
-                ForEach(viewModel.features) { feature in
-                    Section {
-                        RoadmapFeatureView(viewModel: viewModel.featureViewModel(for: feature))
+                Section {
+                    ForEach(viewModel.features) { feature in
+                        Section {
+                            RoadmapFeatureView(viewModel: viewModel.featureViewModel(for: feature))
+                        }
                     }
+                } header: {
+                    header
+                } footer: {
+                    footer
                 }
             }
         }
         #else
         List {
-            ForEach(viewModel.features) { feature in
-                RoadmapFeatureView(viewModel: viewModel.featureViewModel(for: feature))
-                    .listRowSeparator(.hidden)
+            Section {
+                ForEach(viewModel.features) { feature in
+                    RoadmapFeatureView(viewModel: viewModel.featureViewModel(for: feature))
+                        .listRowSeparator(.hidden)
+                }
+            } header: {
+                header
+            } footer: {
+                footer
             }
         }
         .scrollContentBackground(.hidden)
@@ -46,9 +66,27 @@ public struct RoadmapView: View {
 
 }
 
-public extension RoadmapView {
+public extension RoadmapView where Header == EmptyView, Footer == EmptyView {
     init(configuration: RoadmapConfiguration) {
-        self.init(viewModel: .init(configuration: configuration))
+        self.init(viewModel: .init(configuration: configuration), header: EmptyView(), footer: EmptyView())
+    }
+}
+
+public extension RoadmapView where Header: View, Footer == EmptyView {
+    init(configuration: RoadmapConfiguration, @ViewBuilder header: () -> Header) {
+        self.init(viewModel: .init(configuration: configuration), header: header(), footer: EmptyView())
+    }
+}
+
+public extension RoadmapView where Header == EmptyView, Footer: View {
+    init(configuration: RoadmapConfiguration, @ViewBuilder footer: () -> Footer) {
+        self.init(viewModel: .init(configuration: configuration), header: EmptyView(), footer: footer())
+    }
+}
+
+public extension RoadmapView where Header: View, Footer: View {
+    init(configuration: RoadmapConfiguration, @ViewBuilder header: () -> Header, @ViewBuilder footer: () -> Footer) {
+        self.init(viewModel: .init(configuration: configuration), header: header(), footer: footer())
     }
 }
 


### PR DESCRIPTION
- [x] Header and footer can now be configured in `RoadmapView`
- [x] Styling of status view is a little better for contrasts

| iPhone | Mac |
| --- | --- |
| ![RocketSim_Screenshot_iPhone_14_Pro_2023-02-26_16 35 28](https://user-images.githubusercontent.com/4329185/221420389-cd061d6a-9fa9-47ce-af91-75cafd536a91.png) | ![CleanShot 2023-02-26 at 16 35 52@2x](https://user-images.githubusercontent.com/4329185/221420396-fb8e1fd2-ab0a-4682-a56f-f7099d6f8aa2.jpg) |

Fixes #5 