### PR TITLE
Fix: #65. Search bar searches descriptions and titles

### DIFF
--- a/Sources/Roadmap/Models/RoadmapFeature.swift
+++ b/Sources/Roadmap/Models/RoadmapFeature.swift
@@ -19,8 +19,8 @@ public struct RoadmapFeature: Codable, Identifiable {
     var localizedFeatureTitle: String {
         localizedTitle.currentLocal ?? title ?? "N/A"
     }
-    var localizedFeatureDescription: String? {
-        localizedDescription.currentLocal ?? description
+    var localizedFeatureDescription: String {
+        localizedDescription.currentLocal ?? description ?? ""
     }
     var localizedFeatureStatus: String? {
         localizedStatus.currentLocal ?? status

--- a/Sources/Roadmap/RoadmapFeatureView.swift
+++ b/Sources/Roadmap/RoadmapFeatureView.swift
@@ -34,7 +34,7 @@ struct RoadmapFeatureView: View {
                     .font(viewModel.configuration.style.titleFont)
                 
                 let description = viewModel.feature.localizedFeatureDescription
-                if description != "" {
+                if !description.isEmpty {
                     Text(description)
                         .font(viewModel.configuration.style.numberFont)
                         .foregroundColor(Color.secondary)

--- a/Sources/Roadmap/RoadmapFeatureView.swift
+++ b/Sources/Roadmap/RoadmapFeatureView.swift
@@ -33,7 +33,8 @@ struct RoadmapFeatureView: View {
                 Text(viewModel.feature.localizedFeatureTitle)
                     .font(viewModel.configuration.style.titleFont)
                 
-                if let description = viewModel.feature.localizedFeatureDescription {
+                let description = viewModel.feature.localizedFeatureDescription
+                if description != "" {
                     Text(description)
                         .font(viewModel.configuration.style.numberFont)
                         .foregroundColor(Color.secondary)
@@ -82,7 +83,8 @@ struct RoadmapFeatureView: View {
                     }
                 }
                 
-                if let description = viewModel.feature.localizedFeatureDescription {
+                let description = viewModel.feature.localizedFeatureDescription
+                if !description.isEmpty {
                     Text(description)
                         .font(viewModel.configuration.style.numberFont)
                         .foregroundColor(Color.secondary)

--- a/Sources/Roadmap/RoadmapViewModel.swift
+++ b/Sources/Roadmap/RoadmapViewModel.swift
@@ -17,7 +17,11 @@ final class RoadmapViewModel: ObservableObject {
         }
         return features.filter { feature in
             feature
-                .localizedFeatureTitle
+                .localizedFeatureTitle // check title field...
+                .lowercased() // Roadmap localizes strings in Roadmap.json, so avoid .localizedCaseInsensitiveContains()
+                .contains(searchText.lowercased()) ||
+            feature
+                .localizedFeatureDescription // ...and check description field
                 .lowercased()
                 .contains(searchText.lowercased())
         }


### PR DESCRIPTION
Was: Search bar searches titles only.