### PR TITLE
🔓 Enable optional advanced requests for the roadmap endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,19 @@ let configuration = RoadmapConfiguration(
 )
 ```
 
+Optional you can also handover a request for more advanced endpoints, for example protected by OAuth: 
+
+```swift
+
+var request = URLRequest(url: URL(string: "https://simplejsoncms.com/api/k2f11wikc6")!)
+request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+request.setValue("Bearer 1234567890", forHTTPHeaderField: "Authorization")
+
+let configuration = RoadmapConfiguration(
+    roadmapRequest: request
+)
+```
+
 ### Use the configuration to construct the view
 And use the configuration inside the `RoadmapView`:
 
@@ -105,7 +118,7 @@ And use the configuration inside the `RoadmapView`:
 struct ContentView: View {
     let configuration = RoadmapConfiguration(
         roadmapJSONURL: URL(string: "https://simplejsoncms.com/api/k2f11wikc6")!,
-        nameSpace: "yourappname" // Defaults to your apps bundle id
+        namespace: "yourappname" // Defaults to your apps bundle id
         allowVotes: true, // Present the roadmap in read-only mode by setting this to false
         allowSearching: false // Allow users to filter the features list by adding a searchbar
     )

--- a/Sources/Roadmap/DataProviders/FeaturesFetcher.swift
+++ b/Sources/Roadmap/DataProviders/FeaturesFetcher.swift
@@ -8,11 +8,11 @@
 import Foundation
 
 struct FeaturesFetcher {
-    let featureJSONURL: URL
+    let featureRequest: URLRequest
 
     func fetch() async -> [RoadmapFeature] {
         do {
-            return try await JSONDataFetcher.loadJSON(url: featureJSONURL)
+            return try await JSONDataFetcher.loadJSON(request: featureRequest)
         } catch {
             print("error:", error.localizedDescription)
             return []

--- a/Sources/Roadmap/DataProviders/JSONDataFetcher.swift
+++ b/Sources/Roadmap/DataProviders/JSONDataFetcher.swift
@@ -21,6 +21,11 @@ struct JSONDataFetcher {
         return try JSONDecoder().decode(T.self, from: data)
     }
 
+    static func loadJSON<T: Decodable>(request: URLRequest) async throws -> T {
+        let data = try await urlSession.data(for: request).0
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+    
     static func loadJSON<T: Decodable>(fromURLString urlString: String) async throws -> T {
         guard let url = URL(string: urlString) else {
             throw Error.invalidURL

--- a/Sources/Roadmap/RoadmapFeatureView.swift
+++ b/Sources/Roadmap/RoadmapFeatureView.swift
@@ -109,6 +109,6 @@ struct RoadmapFeatureView: View {
 
 struct RoadmapFeatureView_Previews: PreviewProvider {
     static var previews: some View {
-        RoadmapFeatureView(viewModel: .init(feature: .sample(), configuration: .sample()))
+        RoadmapFeatureView(viewModel: .init(feature: .sample(), configuration: .sampleURL()))
     }
 }

--- a/Sources/Roadmap/RoadmapView.swift
+++ b/Sources/Roadmap/RoadmapView.swift
@@ -58,6 +58,6 @@ public extension RoadmapView where Header: View, Footer: View {
 
 struct RoadmapView_Previews: PreviewProvider {
     static var previews: some View {
-        RoadmapView(configuration: .sample())
+        RoadmapView(configuration: .sampleURL())
     }
 }

--- a/Sources/Roadmap/RoadmapViewModel.swift
+++ b/Sources/Roadmap/RoadmapViewModel.swift
@@ -28,15 +28,17 @@ final class RoadmapViewModel: ObservableObject {
     init(configuration: RoadmapConfiguration) {
         self.configuration = configuration
         self.allowSearching = configuration.allowSearching
-        loadFeatures(roadmapJSONURL: configuration.roadmapJSONURL)
+
+        loadFeatures(request: configuration.roadmapRequest)
     }
 
-    func loadFeatures(roadmapJSONURL: URL) {
+    func loadFeatures(request: URLRequest) {
+        
         Task { @MainActor in
             if configuration.shuffledOrder {
-                self.features = await FeaturesFetcher(featureJSONURL: roadmapJSONURL).fetch().shuffled()
+                self.features = await FeaturesFetcher(featureRequest: request).fetch().shuffled()
             } else {
-                self.features = await FeaturesFetcher(featureJSONURL: roadmapJSONURL).fetch()
+                self.features = await FeaturesFetcher(featureRequest: request).fetch()
             }
         }
     }


### PR DESCRIPTION
It's already a while ago I made my first request for this, but I didn't found the time to continue. Here a new one on the latest codebase and with the review feedback (#50) in mind. 

**🧐 Problem**
As a developer I want to be able to point to a roadmap endpoint which is protected. Currently I can only provide a simple URL. This is nice, but we need one more step.

**💡 Solution:**
In many cases the protection works by a bearer token inside the request header. A way to handover a Request instead of only the URL helps to set a header for the authentication against the backend like...

```
var request = URLRequest(url: URL(string: "https://my-protected-endpoint-url-to-the-roadmap-features"))
request.setValue("application/json", forHTTPHeaderField: "Content-Type")
request.setValue("Bearer 1234567890", forHTTPHeaderField: "Authorization")

configuration = RoadmapConfiguration(
        roadmapRequest: request,
        ...
```

**✍️ Changes:**
- updated configuration for an optional URLRequest instead of a URL for an advanced way to fetch the roadmap
- updated README

Keep up the good work. 👏