### PR TITLE
Unvote functionality. Move hasVoted assignment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ public struct RoadmapStyle {
     /// The image used for the upvote button
     let upvoteIcon : Image
     
+    /// The image used for the unvote button
+    let unvoteIcon : Image
+    
     /// The font used for the feature
     let titleFont : Font
     
@@ -151,7 +154,8 @@ public struct RoadmapStyle {
     /// The main tintColor for the roadmap views.
     let tintColor : Color
     
-    public init(icon: Image,
+    public init(upvoteIcon: Image,
+                unvoteIcon: Image,
                 titleFont: Font,
                 numberFont: Font,
                 statusFont: Font,

--- a/Sources/Roadmap/DataProviders/FeatureVoter.swift
+++ b/Sources/Roadmap/DataProviders/FeatureVoter.swift
@@ -10,8 +10,12 @@ import Foundation
 public protocol FeatureVoter {
     /// Fetches the current count for the given feature.
     func fetch(for feature: RoadmapFeature) async -> Int
-    
+
     /// Votes for the given feature.
     /// - Returns: The new `count` if successful.
     func vote(for feature: RoadmapFeature) async -> Int?
+
+    /// Removes a vote for the given feature.
+    /// - Returns: The new `count` if successful.
+    func unvote(for feature: RoadmapFeature) async -> Int?
 }

--- a/Sources/Roadmap/DataProviders/FeatureVoterCountAPI.swift
+++ b/Sources/Roadmap/DataProviders/FeatureVoterCountAPI.swift
@@ -43,10 +43,29 @@ public struct FeatureVoterCountAPI: FeatureVoter {
         }
         
         do {
+            // we must use hit because we do not know in advance if the namespace exists, and hit will create it for us.
             let urlString = "https://api.countapi.xyz/hit/\(namespace)/feature\(feature.id)"
             let count: RoadmapFeatureVotingCount = try await JSONDataFetcher.loadJSON(fromURLString: urlString)
-            feature.hasVoted = true
             print("Successfully voted, count is now: \(count)")
+            return count.value
+        } catch {
+            print("Voting failed: \(error.localizedDescription)")
+            return nil
+        }
+    }
+    
+    /// Votes for the given feature.
+    /// - Returns: The new `count` if successful.
+    public func unvote(for feature: RoadmapFeature) async -> Int? {
+        guard feature.hasNotFinished else {
+            return nil
+        }
+        
+        do {
+            // "update" does not create the namespace if it does not exist, therefore we cannot combine vote and unvote into a +1/-1
+            let urlString = "https://api.countapi.xyz/update/\(namespace)/feature\(feature.id)?amount=-1"
+            let count: RoadmapFeatureVotingCount = try await JSONDataFetcher.loadJSON(fromURLString: urlString)
+            print("Successfully unvoted, count is now: \(count)")
             return count.value
         } catch {
             print("Voting failed: \(error.localizedDescription)")

--- a/Sources/Roadmap/RoadmapFeatureViewModel.swift
+++ b/Sources/Roadmap/RoadmapFeatureViewModel.swift
@@ -14,15 +14,14 @@ final class RoadmapFeatureViewModel: ObservableObject {
     let canVote: Bool
 
     @Published var voteCount = 0
-    
 
     init(feature: RoadmapFeature, configuration: RoadmapConfiguration) {
         self.feature = feature
         self.configuration = configuration
-        
+
         self.canVote = configuration.allowVotes
     }
-    
+
     @MainActor
     func getCurrentVotes() async {
         voteCount = await configuration.voter.fetch(for: feature)
@@ -30,12 +29,15 @@ final class RoadmapFeatureViewModel: ObservableObject {
 
     @MainActor
     func vote() async {
-        guard !feature.hasVoted else {
-            print("already voted for this, can't vote again")
-            return
-        }
-        
         let newCount = await configuration.voter.vote(for: feature)
         voteCount = newCount ?? (voteCount + 1)
+        feature.hasVoted = true
+    }
+
+    @MainActor
+    func unvote() async {
+        let newCount = await configuration.voter.unvote(for: feature)
+        voteCount = newCount ?? (voteCount - 1)
+        feature.hasVoted = false
     }
 }

--- a/Sources/Roadmap/RoadmapVoteButton.swift
+++ b/Sources/Roadmap/RoadmapVoteButton.swift
@@ -35,11 +35,19 @@ struct RoadmapVoteButton: View {
                 if typeSize.isAccessibilitySize {
                     HStack(spacing: isHovering ? 2 : 0) {
                         if viewModel.canVote {
-                            viewModel.configuration.style.upvoteIcon
-                                .foregroundColor(hasVoted ? viewModel.configuration.style.selectedForegroundColor : viewModel.configuration.style.tintColor)
-                                .imageScale(.large)
-                                .font(Font.system(size: 17, weight: .medium))
-                                .frame(maxWidth: 24, maxHeight: 24)
+                            if !viewModel.feature.hasVoted {
+                                viewModel.configuration.style.upvoteIcon
+                                    .foregroundColor(hasVoted ? viewModel.configuration.style.selectedForegroundColor : viewModel.configuration.style.tintColor)
+                                    .imageScale(.large)
+                                    .font(Font.system(size: 17, weight: .medium))
+                                    .frame(maxWidth: 24, maxHeight: 24)
+                            } else {
+                                viewModel.configuration.style.unvoteIcon
+                                    .foregroundColor(hasVoted ? viewModel.configuration.style.selectedForegroundColor : viewModel.configuration.style.tintColor)
+                                    .imageScale(.large)
+                                    .font(Font.system(size: 17, weight: .medium))
+                                    .frame(maxWidth: 24, maxHeight: 24)
+                            }
                         }
                         
                         if showNumber {
@@ -56,12 +64,21 @@ struct RoadmapVoteButton: View {
                 } else {
                     VStack(spacing: isHovering ? 6 : 4) {
                         if viewModel.canVote {
-                            viewModel.configuration.style.upvoteIcon
-                                .foregroundColor(hasVoted ? viewModel.configuration.style.selectedForegroundColor : viewModel.configuration.style.tintColor)
-                                .imageScale(.large)
-                                .font(viewModel.configuration.style.numberFont)
-                                .frame(maxWidth: 20, maxHeight: 20)
-                                .minimumScaleFactor(0.75)
+                            if !viewModel.feature.hasVoted {
+                                viewModel.configuration.style.upvoteIcon
+                                    .foregroundColor(hasVoted ? viewModel.configuration.style.selectedForegroundColor : viewModel.configuration.style.tintColor)
+                                    .imageScale(.large)
+                                    .font(viewModel.configuration.style.numberFont)
+                                    .frame(maxWidth: 20, maxHeight: 20)
+                                    .minimumScaleFactor(0.75)
+                            } else {
+                                viewModel.configuration.style.unvoteIcon
+                                    .foregroundColor(hasVoted ? viewModel.configuration.style.selectedForegroundColor : viewModel.configuration.style.tintColor)
+                                    .imageScale(.large)
+                                    .font(viewModel.configuration.style.numberFont)
+                                    .frame(maxWidth: 20, maxHeight: 20)
+                                    .minimumScaleFactor(0.75)
+                            }
                         }
                         
                         if showNumber {
@@ -106,8 +123,8 @@ struct RoadmapVoteButton: View {
                 hasVoted = viewModel.feature.hasVoted
             }
         }
-        .accessibilityHint(viewModel.canVote ? Text("Vote for \(viewModel.feature.localizedFeatureTitle)") : Text(""))
-        .help(viewModel.canVote ? "Vote for \(viewModel.feature.localizedFeatureTitle)" : "")
+        .accessibilityHint(viewModel.canVote ? !viewModel.feature.hasVoted ? Text("Vote for \(viewModel.feature.localizedFeatureTitle)") : Text("Remove vote for \(viewModel.feature.localizedFeatureTitle)") : Text(""))
+        .help(viewModel.canVote ? !viewModel.feature.hasVoted ? Text("Vote for \(viewModel.feature.localizedFeatureTitle)") : Text("Remove vote for \(viewModel.feature.localizedFeatureTitle)") : Text(""))
         .animateAccessible()
         .accessibilityShowsLargeContentViewer()
     }

--- a/Sources/Roadmap/RoadmapVoteButton.swift
+++ b/Sources/Roadmap/RoadmapVoteButton.swift
@@ -1,15 +1,14 @@
 //
 //  RoadmapVoteButton.swift
-//  
+//
 //
 //  Created by Hidde van der Ploeg on 20/02/2023.
 //
 
 import SwiftUI
 
-
-struct RoadmapVoteButton : View {
-    @ObservedObject var viewModel : RoadmapFeatureViewModel
+struct RoadmapVoteButton: View {
+    @ObservedObject var viewModel: RoadmapFeatureViewModel
     @Environment(\.dynamicTypeSize) var typeSize
     
     @State private var isHovering = false
@@ -20,7 +19,11 @@ struct RoadmapVoteButton : View {
         Button {
             if viewModel.canVote {
                 Task {
-                    await viewModel.vote()
+                    if !viewModel.feature.hasVoted {
+                        await viewModel.vote()
+                    } else {
+                        await viewModel.unvote()
+                    }
                     #if os(iOS)
                     let haptic = UIImpactFeedbackGenerator(style: .soft)
                     haptic.impactOccurred()
@@ -73,7 +76,6 @@ struct RoadmapVoteButton : View {
                     .frame(height: 64)
                     .background(backgroundView)
                 }
-                
             }
             .contentShape(RoundedRectangle(cornerRadius: viewModel.configuration.style.radius, style: .continuous))
             .overlay(overlayBorder)
@@ -111,17 +113,16 @@ struct RoadmapVoteButton : View {
     }
     
     @ViewBuilder
-    var overlayBorder : some View {
+    var overlayBorder: some View {
         if isHovering {
             RoundedRectangle(cornerRadius: viewModel.configuration.style.radius, style: .continuous)
                 .stroke(viewModel.configuration.style.tintColor, lineWidth: 1)
         }
     }
     
-    private var backgroundView : some View {
+    private var backgroundView: some View {
         viewModel.configuration.style.tintColor
             .opacity(hasVoted ? 1 : 0.1)
             .clipShape(RoundedRectangle(cornerRadius: viewModel.configuration.style.radius, style: .continuous))
     }
-    
 }

--- a/Sources/Roadmap/Styling/RoadmapStyle.swift
+++ b/Sources/Roadmap/Styling/RoadmapStyle.swift
@@ -9,35 +9,39 @@ import SwiftUI
 
 public struct RoadmapStyle {
     /// The image used for the upvote button
-    public var upvoteIcon : Image
+    public var upvoteIcon: Image
+    
+    /// The image used for the unvote button
+    public var unvoteIcon: Image
     
     /// The font used for the feature
-    public var titleFont : Font
+    public var titleFont: Font
     
     /// The font used for the count label
-    public var numberFont : Font
+    public var numberFont: Font
     
     /// The font used for the status views
-    public var statusFont : Font
+    public var statusFont: Font
     
     /// The tint color of the status view
     public var statusTintColor: (String) -> Color
     
     /// The corner radius for the upvote button
-    public var radius : CGFloat
+    public var radius: CGFloat
     
     /// The backgroundColor of each cell
-    public var cellColor : Color
+    public var cellColor: Color
     
     /// The color of the text and icon when voted
-    public var selectedForegroundColor : Color
+    public var selectedForegroundColor: Color
     
     /// The main tintColor for the roadmap views.
-    public var tintColor : Color
+    public var tintColor: Color
     
     /// Define a `RoadmapStyle` to customise Roadmap to your needs
     /// - Parameters:
-    ///   - icon: Image view that you want to use for the upvote icon 24x24 of size is best
+    ///   - upvoteIcon: Image view that you want to use for the upvote icon 24x24 of size is best
+    ///   - unvoteIcon: Image view that you want to use for the upvote icon 24x24 of size is best
     ///   - titleFont: The font you want
     ///   - numberFont: The font used for the count label
     ///   - statusFont: The font used for the status views
@@ -46,7 +50,8 @@ public struct RoadmapStyle {
     ///   - cellColor: The backgroundColor of each cell
     ///   - selectedColor: The color of the text and icon when voted
     ///   - tint: The main tintColor for the roadmap views.
-    public init(icon: Image,
+    public init(upvoteIcon: Image,
+                unvoteIcon: Image,
                 titleFont: Font,
                 numberFont: Font,
                 statusFont: Font,
@@ -54,9 +59,10 @@ public struct RoadmapStyle {
                 cornerRadius: CGFloat,
                 cellColor: Color = Color.defaultCellColor,
                 selectedColor: Color = .white,
-                tint: Color = .accentColor) {
-        
-        self.upvoteIcon = icon
+                tint: Color = .accentColor)
+    {
+        self.upvoteIcon = upvoteIcon
+        self.unvoteIcon = unvoteIcon
         self.titleFont = titleFont
         self.numberFont = numberFont
         self.statusFont = statusFont

--- a/Sources/Roadmap/Styling/RoadmapTemplates.swift
+++ b/Sources/Roadmap/Styling/RoadmapTemplates.swift
@@ -1,39 +1,43 @@
 //
 //  RoadmapTemplates.swift
-//  
+//
 //
 //  Created by Hidde van der Ploeg on 20/02/2023.
 //
 
 import SwiftUI
-public enum RoadmapTemplate : CaseIterable {
+public enum RoadmapTemplate: CaseIterable {
     case standard
     case playful
     case classy
     case technical
     
-    public var style : RoadmapStyle {
+    public var style: RoadmapStyle {
         switch self {
         case .standard:
-            return RoadmapStyle(icon: Image(systemName: "arrowtriangle.up.fill"),
+            return RoadmapStyle(upvoteIcon: Image(systemName: "arrowtriangle.up.fill"),
+                                unvoteIcon: Image(systemName: "arrowtriangle.down.fill"),
                                 titleFont: self.titleFont,
                                 numberFont: self.numberFont,
                                 statusFont: self.captionFont,
                                 cornerRadius: 10)
         case .playful:
-            return RoadmapStyle(icon: Image(systemName: "arrow.up"),
+            return RoadmapStyle(upvoteIcon: Image(systemName: "arrow.up"),
+                                unvoteIcon: Image(systemName: "arrow.down"),
                                 titleFont: self.titleFont,
                                 numberFont: self.numberFont,
                                 statusFont: self.captionFont,
                                 cornerRadius: 15)
         case .classy:
-            return RoadmapStyle(icon: Image(systemName: "chevron.up"),
+            return RoadmapStyle(upvoteIcon: Image(systemName: "chevron.up"),
+                                unvoteIcon: Image(systemName: "chevron.down"),
                                 titleFont: self.titleFont,
                                 numberFont: self.numberFont,
                                 statusFont: self.captionFont,
                                 cornerRadius: 5)
         case .technical:
-            return RoadmapStyle(icon: Image(systemName: "chevron.up"),
+            return RoadmapStyle(upvoteIcon: Image(systemName: "chevron.up"),
+                                unvoteIcon: Image(systemName: "chevron.down"),
                                 titleFont: self.titleFont,
                                 numberFont: self.numberFont,
                                 statusFont: self.captionFont,
@@ -41,7 +45,7 @@ public enum RoadmapTemplate : CaseIterable {
         }
     }
     
-    var fontDesign : Font.Design {
+    var fontDesign: Font.Design {
         switch self {
         case .playful:
             return .rounded

--- a/Tests/RoadmapTests/RoadmapTests.swift
+++ b/Tests/RoadmapTests/RoadmapTests.swift
@@ -41,13 +41,11 @@ class InMemoryFeatureVoter: FeatureVoter {
     
     func vote(for feature: RoadmapFeature) async -> Int? {
         count[feature.id] = await fetch(for: feature) + 1
-        feature.hasVoted = true
         return count[feature.id]
     }
     
     func unvote(for feature: RoadmapFeature) async -> Int? {
         count[feature.id] = await fetch(for: feature) - 1
-        feature.hasVoted = true
         return count[feature.id]
     }
 }

--- a/Tests/RoadmapTests/RoadmapTests.swift
+++ b/Tests/RoadmapTests/RoadmapTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import Roadmap
+import XCTest
 
 final class RoadmapTests: XCTestCase {
     func testFeatureVoter() async throws {
@@ -25,6 +25,10 @@ final class RoadmapTests: XCTestCase {
         await model.vote()
         XCTAssertEqual(model.voteCount, 2)
         XCTAssertTrue(feature.hasVoted)
+        
+        await model.unvote()
+        XCTAssertEqual(model.voteCount, 1)
+        XCTAssertFalse(feature.hasVoted)
     }
 }
 
@@ -37,6 +41,12 @@ class InMemoryFeatureVoter: FeatureVoter {
     
     func vote(for feature: RoadmapFeature) async -> Int? {
         count[feature.id] = await fetch(for: feature) + 1
+        feature.hasVoted = true
+        return count[feature.id]
+    }
+    
+    func unvote(for feature: RoadmapFeature) async -> Int? {
+        count[feature.id] = await fetch(for: feature) - 1
         feature.hasVoted = true
         return count[feature.id]
     }


### PR DESCRIPTION
This PR solves two issues I am encountering:

1. I cannot implement a custom `FeatureVoter` because `.hasVoted` is internal, and that value is set in the `FeatureVoterCountAPI` implementation.
  a. This is solved by moving the assignment to the caller in the model.
2. I would like users to be able to remove a vote by tapping the button again.
  a. This is solved by adding `unvote` and using the `update` endpoint on countapi.

Additionally, I've added an `unvoteImage` concept. If a user has already voted for an option, the arrow will switch to the `unvoteImage`. This is, by default, just the "down arrow" version of the "up arrow" image.