### PR TITLE
Add basic watchOS support to better support multi platform apps

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,8 @@ let package = Package(
     name: "Roadmap",
     platforms: [
         .iOS(.v15),
-        .macOS(.v12)
+        .macOS(.v12),
+        .watchOS(.v9)
     ],
     products: [
         .library(name: "Roadmap", targets: ["Roadmap"]),

--- a/Sources/Roadmap/Extensions/ColorExtensions.swift
+++ b/Sources/Roadmap/Extensions/ColorExtensions.swift
@@ -10,7 +10,7 @@ import SwiftUI
 extension Color {
     
     static public var defaultCellColor : Color {
-        #if os(macOS)
+        #if os(macOS) || os(watchOS)
             return Color.primary.opacity(0.08)
         #else
             return Color(uiColor: .secondarySystemFill)

--- a/Sources/Roadmap/Extensions/ViewExtensions.swift
+++ b/Sources/Roadmap/Extensions/ViewExtensions.swift
@@ -23,11 +23,15 @@ extension View {
 
     @ViewBuilder
     func macOSListRowSeparatorHidden() -> some View {
-        if #available(macOS 13.0, *) {
-            self.listRowSeparator(.hidden)
-        } else {
-            self
-        }
+        #if os(macOS)
+          if #available(macOS 13.0, *) {
+              self.listRowSeparator(.hidden)
+          } else {
+              self
+          }
+        #else
+          self
+        #endif
     }
 
     @ViewBuilder

--- a/Sources/Roadmap/RoadmapVoteButton.swift
+++ b/Sources/Roadmap/RoadmapVoteButton.swift
@@ -110,6 +110,7 @@ struct RoadmapVoteButton: View {
                 hasVoted = newVote
             }
         }
+        #if !os(watchOS)
         .onHover { newHover in
             if viewModel.canVote && !hasVoted {
                 withAnimation(.spring(response: 0.4, dampingFraction: 0.7, blendDuration: 0)) {
@@ -117,6 +118,7 @@ struct RoadmapVoteButton: View {
                 }
             }
         }
+        #endif
         .onAppear {
             showNumber = viewModel.voteCount > 0
             withAnimation(.spring(response: 0.45, dampingFraction: 0.4, blendDuration: 0)) {


### PR DESCRIPTION
This PR is mainly to prevent compile time errors and doesn’t implement a good UX on watchOS. I have a multiplatform app. With Xcode 15 I can't build my app anymore as Roadmap fails to compile for watchOS. I think in most cases a Roadmap doesn't make sense on watchOS. But I'm not aware of a good way to restrict platforms for a Swift package.

https://forums.swift.org/t/restrict-platforms-for-packages/29456/7

Not mentioning watchOS in platforms just means the oldest watchOS version is supported implicitly.

I'm not 100% sure yet why Xcode even tries to compile Roadmap for watchOS in my project. I only have it as a dependency in my own Package.swift for a library target that is only added to an iOS target. I also added a TargetDependencyCondition `.product(name: "Roadmap", package: "Roadmap", condition: .when(platforms: [.iOS])),` And the actual view is surrounded with `#if os(iOS) #endif` But this iOS target also embeds my watchOS target.

This PR only fixes the errors. I didn't make any other changes so the watchOS UX is probably not very good. I don't plan to use Roadmap on my watchOS app anyway. But this is how the preview looks.

<img width="271" alt="Bildschirmfoto 2023-10-07 um 12 41 16" src="https://github.com/AvdLee/Roadmap/assets/1190948/dcad6cca-490e-4dec-849c-213e8dd67d3a">

