### PR TITLE
Set selected filter initially to all to match picker option

### DIFF
--- a/Sources/Roadmap/RoadmapView.swift
+++ b/Sources/Roadmap/RoadmapView.swift
@@ -79,19 +79,19 @@ public extension RoadmapView where Header == EmptyView, Footer == EmptyView {
 
 public extension RoadmapView where Header: View, Footer == EmptyView {
     init(configuration: RoadmapConfiguration, @ViewBuilder header: () -> Header) {
-        self.init(viewModel: .init(configuration: configuration), header: header(), footer: EmptyView(), selectedFilter: "")
+        self.init(viewModel: .init(configuration: configuration), header: header(), footer: EmptyView(), selectedFilter: "all")
     }
 }
 
 public extension RoadmapView where Header == EmptyView, Footer: View {
     init(configuration: RoadmapConfiguration, @ViewBuilder footer: () -> Footer) {
-        self.init(viewModel: .init(configuration: configuration), header: EmptyView(), footer: footer(), selectedFilter: "")
+        self.init(viewModel: .init(configuration: configuration), header: EmptyView(), footer: footer(), selectedFilter: "all")
     }
 }
 
 public extension RoadmapView where Header: View, Footer: View {
     init(configuration: RoadmapConfiguration, @ViewBuilder header: () -> Header, @ViewBuilder footer: () -> Footer) {
-        self.init(viewModel: .init(configuration: configuration), header: header(), footer: footer(), selectedFilter: "")
+        self.init(viewModel: .init(configuration: configuration), header: header(), footer: footer(), selectedFilter: "all")
     }
 }
 


### PR DESCRIPTION
The status filter picker is initialized with an empty string "" currently, but this is not an option in the picker. So SwiftUI complains with a fault log:

Picker: the selection "" is invalid and does not have an associated tag, this will give undefined results.

This PR initializes this with "all", which is always available. Other ways could be to just default the State to "all" and to remove the argument from the auto generated init. Or make it user configurable. But I don't have time for this so this is a quick fix.

<img width="784" alt="Bildschirmfoto 2024-03-22 um 18 39 24" src="https://github.com/AvdLee/Roadmap/assets/1190948/c08c1882-1964-489e-bcc7-a95d85d52407">
