### PR TITLE
Add votes field to RoadmapFeature

### DIFF
--- a/Sources/Roadmap/Models/RoadmapFeature.swift
+++ b/Sources/Roadmap/Models/RoadmapFeature.swift
@@ -11,6 +11,7 @@ public struct RoadmapFeature: Codable, Identifiable {
     public let id: String
     public let title: String?
     public var status: String? = nil
+    public var votes: Int? = nil
     private var description : String? = nil
     private var localizedTitle: [LocalizedItem]? = nil
     private var localizedStatus: [LocalizedItem]? = nil

--- a/Sources/Roadmap/RoadmapFeatureViewModel.swift
+++ b/Sources/Roadmap/RoadmapFeatureViewModel.swift
@@ -24,7 +24,11 @@ final class RoadmapFeatureViewModel: ObservableObject {
 
     @MainActor
     func getCurrentVotes() async {
-        voteCount = await configuration.voter.fetch(for: feature)
+        if let votes = feature.votes {
+            voteCount = votes
+        } else {
+            voteCount = await configuration.voter.fetch(for: feature)
+        }
     }
 
     @MainActor


### PR DESCRIPTION
I added a votes field to the RoadmapFeature model type to allow the data source to return the current number of votes with the feature list download and not require separate API calls for each feature. I retained existing functionality by making the votes field optional and defaulting to the previous behavior if the field is not present in the JSON.

For background context, I created my own backend API for managing features for my application. I'm providing the API call as a `URLRequest` to the `RoadmapConfiguration` object. My API can retrieve all of the feature data including the current vote count for features and return them. This PR eliminates the need to have a separate service or API for managing vote counts. The `FeatureVoter` protocol is still being used to up-vote and down-vote features as I have separate REST APIs defined for that.