### PR TITLE
Add tap gesture to provide additional feature info

### DIFF
--- a/Example/RoadmapExample/RoadmapExample/ContentView.swift
+++ b/Example/RoadmapExample/RoadmapExample/ContentView.swift
@@ -16,7 +16,7 @@ struct ContentView: View {
         allowSearching: true,
         allowsFilterByStatus: true
     )
-
+    
     var body: some View {
         #if os(macOS)
             roadmapView

--- a/Sources/Roadmap/Models/RoadmapFeature.swift
+++ b/Sources/Roadmap/Models/RoadmapFeature.swift
@@ -7,10 +7,11 @@
 
 import Foundation
 
-public struct RoadmapFeature: Codable, Identifiable {
+public struct RoadmapFeature: Codable, Identifiable, Equatable {
     public let id: String
     public let title: String?
     public var status: String? = nil
+    public var url: URL? = nil
     private var description : String? = nil
     private var localizedTitle: [LocalizedItem]? = nil
     private var localizedStatus: [LocalizedItem]? = nil
@@ -52,7 +53,7 @@ public struct RoadmapFeature: Codable, Identifiable {
     }
 }
 
-struct LocalizedItem: Codable {
+struct LocalizedItem: Codable, Equatable {
     let language: String
     let value: String
 }

--- a/Sources/Roadmap/RoadmapView.swift
+++ b/Sources/Roadmap/RoadmapView.swift
@@ -12,6 +12,7 @@ public struct RoadmapView<Header: View, Footer: View>: View {
     let header: Header
     let footer: Footer
     @State private var selectedFilter: String
+    @Binding var selectedFeature: RoadmapFeature?
     
     private var filterHorizontalPadding: CGFloat {
         #if os(macOS)
@@ -64,6 +65,9 @@ public struct RoadmapView<Header: View, Footer: View>: View {
                     RoadmapFeatureView(viewModel: viewModel.featureViewModel(for: feature))
                         .macOSListRowSeparatorHidden()
                         .listRowBackground(Color.clear)
+                        .onTapGesture {
+                            selectedFeature = feature
+                        }
                 }
                 footer
             }
@@ -72,26 +76,26 @@ public struct RoadmapView<Header: View, Footer: View>: View {
 }
 
 public extension RoadmapView where Header == EmptyView, Footer == EmptyView {
-    init(configuration: RoadmapConfiguration) {
-        self.init(viewModel: .init(configuration: configuration), header: EmptyView(), footer: EmptyView(), selectedFilter: "")
+    init(configuration: RoadmapConfiguration, selectedFeature: Binding<RoadmapFeature?> = .constant(nil)) {
+        self.init(viewModel: .init(configuration: configuration), header: EmptyView(), footer: EmptyView(), selectedFilter: "", selectedFeature: selectedFeature)
     }
 }
 
 public extension RoadmapView where Header: View, Footer == EmptyView {
-    init(configuration: RoadmapConfiguration, @ViewBuilder header: () -> Header) {
-        self.init(viewModel: .init(configuration: configuration), header: header(), footer: EmptyView(), selectedFilter: "")
+    init(configuration: RoadmapConfiguration, @ViewBuilder header: () -> Header, selectedFeature: Binding<RoadmapFeature?> = .constant(nil)) {
+        self.init(viewModel: .init(configuration: configuration), header: header(), footer: EmptyView(), selectedFilter: "", selectedFeature: selectedFeature)
     }
 }
 
 public extension RoadmapView where Header == EmptyView, Footer: View {
-    init(configuration: RoadmapConfiguration, @ViewBuilder footer: () -> Footer) {
-        self.init(viewModel: .init(configuration: configuration), header: EmptyView(), footer: footer(), selectedFilter: "")
+    init(configuration: RoadmapConfiguration, @ViewBuilder footer: () -> Footer, selectedFeature: Binding<RoadmapFeature?> = .constant(nil)) {
+        self.init(viewModel: .init(configuration: configuration), header: EmptyView(), footer: footer(), selectedFilter: "", selectedFeature: selectedFeature)
     }
 }
 
 public extension RoadmapView where Header: View, Footer: View {
-    init(configuration: RoadmapConfiguration, @ViewBuilder header: () -> Header, @ViewBuilder footer: () -> Footer) {
-        self.init(viewModel: .init(configuration: configuration), header: header(), footer: footer(), selectedFilter: "")
+    init(configuration: RoadmapConfiguration, @ViewBuilder header: () -> Header, @ViewBuilder footer: () -> Footer, selectedFeature: Binding<RoadmapFeature?> = .constant(nil)) {
+        self.init(viewModel: .init(configuration: configuration), header: header(), footer: footer(), selectedFilter: "", selectedFeature: selectedFeature)
     }
 }
 


### PR DESCRIPTION
I enhanced `RoadmapFeature` by adding a `url` property that can be used to display additional information about the feature request, such as a GitHub issue or a blog post.

I enhanced `RoadmapView` by adding a bindable variable for the selected feature in the list. I added a tap gesture recognizer that will update the bindable value with the selected feature. This will allow a developer to navigate to another view to show more detailed information about the feature, or to use the new `url` field to open a web view to show the detailed information about the feature.

I had to extend `RoadmapFeature` to implement `Equatable`. If a developer uses the new bindable field on `RoadmapView` and uses the `onChange(of:)` view modifier to react to a feature being selected, the type is required to conform to `Equatable`.