### PR TITLE
Contribute Sidetrack Voting Service

### DIFF
--- a/Example/RoadmapExample/RoadmapExample/ContentView.swift
+++ b/Example/RoadmapExample/RoadmapExample/ContentView.swift
@@ -10,8 +10,8 @@ import SwiftUI
 
 struct ContentView: View {
     let configuration = RoadmapConfiguration(
-        roadmapJSONURL: URL(string: "https://simplejsoncms.com/api/k2f11wikc6")!,
-        namespace: "roadmaptest",
+        roadmapJSONURL: URL(string: "https://roadmap.sidetrack.app/roadmap/669827fe83191f8a3a802b4d")!,
+        voter: FeatureVoterSidetrack(),
         allowVotes: true,
         allowSearching: true,
         allowsFilterByStatus: true

--- a/Sources/Roadmap/DataProviders/FeatureVoterSidetrack.swift
+++ b/Sources/Roadmap/DataProviders/FeatureVoterSidetrack.swift
@@ -1,0 +1,78 @@
+//
+//  FeatureVoterSidetrack.swift
+//  Roadmap
+//
+//  Created by Antoine van der Lee on 19/02/2023.
+//
+
+import Foundation
+
+public struct FeatureVoterSidetrack: FeatureVoter {
+    public init() {}
+    
+    /// Fetches the current count for the given feature.
+    /// - Returns: The current `count`, else `0` if unsuccessful.
+    public func fetch(for feature: RoadmapFeature) async -> Int {
+        guard feature.hasNotFinished else {
+            return 0
+        }
+        
+        do {
+            let urlString = "https://roadmap.sidetrack.app/item/\(feature.id)"
+            let count: RoadmapFeatureVotingCount = try await JSONDataFetcher.loadJSON(fromURLString: urlString)
+            return count.value ?? 0
+        } catch {
+            print(error)
+            print("Fetching voting count failed with error: \(error.localizedDescription)")
+            return 0
+        }
+    }
+
+    /// Votes for the given feature.
+    /// - Returns: The new `count` if successful.
+    public func vote(for feature: RoadmapFeature) async -> Int? {
+        guard feature.hasNotFinished else {
+            return nil
+        }
+        
+        do {
+            guard let url = URL(string: "https://roadmap.sidetrack.app/item/\(feature.id)/vote") else {
+                throw JSONDataFetcher.Error.invalidURL
+            }
+            
+            var request = URLRequest(url: url)
+            request.httpMethod = "POST"
+            
+            let count: RoadmapFeatureVotingCount = try await JSONDataFetcher.loadJSON(request: request)
+            print("Successfully voted, count is now: \(count)")
+            return count.value
+        } catch {
+            print("Voting failed: \(error.localizedDescription)")
+            return nil
+        }
+    }
+    
+    /// Votes for the given feature.
+    /// - Returns: The new `count` if successful.
+    public func unvote(for feature: RoadmapFeature) async -> Int? {
+        guard feature.hasNotFinished else {
+            return nil
+        }
+        
+        do {
+            guard let url = URL(string: "https://roadmap.sidetrack.app/item/\(feature.id)/unvote") else {
+                throw JSONDataFetcher.Error.invalidURL
+            }
+            
+            var request = URLRequest(url: url)
+            request.httpMethod = "POST"
+            
+            let count: RoadmapFeatureVotingCount = try await JSONDataFetcher.loadJSON(request: request)
+            print("Successfully unvoted, count is now: \(count)")
+            return count.value
+        } catch {
+            print("Voting failed: \(error.localizedDescription)")
+            return nil
+        }
+    }
+}

--- a/Sources/Roadmap/Models/RoadmapFeature.swift
+++ b/Sources/Roadmap/Models/RoadmapFeature.swift
@@ -15,6 +15,7 @@ public struct RoadmapFeature: Codable, Identifiable {
     private var localizedTitle: [LocalizedItem]? = nil
     private var localizedStatus: [LocalizedItem]? = nil
     private var localizedDescription: [LocalizedItem]? = nil
+    public var votes: Int? = nil
     
     var localizedFeatureTitle: String {
         localizedTitle.currentLocal ?? title ?? "N/A"

--- a/Sources/Roadmap/RoadmapFeatureView.swift
+++ b/Sources/Roadmap/RoadmapFeatureView.swift
@@ -22,7 +22,7 @@ struct RoadmapFeatureView: View {
         .background(viewModel.configuration.style.cellColor)
         .clipShape(RoundedRectangle(cornerRadius: viewModel.configuration.style.radius, style: .continuous))
         .task {
-            await viewModel.getCurrentVotes()
+            await viewModel.getCurrentVotes(firstLoad: true)
         }
         
     }

--- a/Sources/Roadmap/RoadmapFeatureViewModel.swift
+++ b/Sources/Roadmap/RoadmapFeatureViewModel.swift
@@ -23,8 +23,12 @@ final class RoadmapFeatureViewModel: ObservableObject {
     }
 
     @MainActor
-    func getCurrentVotes() async {
-        voteCount = await configuration.voter.fetch(for: feature)
+    func getCurrentVotes(firstLoad: Bool = false) async {
+        if let votes = feature.votes, firstLoad {
+            voteCount = votes
+        } else {
+            voteCount = await configuration.voter.fetch(for: feature)
+        }
     }
 
     @MainActor


### PR DESCRIPTION
Hey folks 👋  - especially @AvdLee.

I am more than okay if this PR is declined, ignored, etc. Though much like others who may use this am aware of the difficulties with CountAPI.XYZ service this project defaults to.

I have created and deployed a service among a suite of other mobile tools on my Sidetrack domain I use for indie development. Unlike CountAPI it does not accept anonymous counting, but does support free access for people to create their own roadmaps with an attached public counter. APIs have been intentionally designed to work with this project.

Attached is my local voter implementation I use in my own apps. If others want to benefit from it, then please go ahead. If others would rather stand clear, then that is of course okay.

I've updated the example project with a demonstration roadmap copied from the original SimpleJSONCMS file used.