### PR TITLE
Backport package.json target to macOS 12

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Workspace
-   version = "1.0">
-   <FileRef
-      location = "self:">
-   </FileRef>
-</Workspace>

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "Roadmap",
     platforms: [
         .iOS(.v17),
-        .macOS(.v14),
+        .macOS(.v12),
         .visionOS(.v1)
     ],
     products: [

--- a/Sources/Roadmap/RoadmapFeatureView.swift
+++ b/Sources/Roadmap/RoadmapFeatureView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+@available(macOS 14.0, iOS 17.0, visionOS 1.0, *)
 struct RoadmapFeatureView: View {
     @Environment(\.dynamicTypeSize) var typeSize
     @State var viewModel: RoadmapFeatureViewModel
@@ -110,6 +111,7 @@ struct RoadmapFeatureView: View {
     }
 }
 
+@available(macOS 14.0, iOS 17.0, visionOS 1.0, *)
 #Preview {
     RoadmapFeatureView(viewModel: .init(feature: .sample(), configuration: .sampleURL()))
 }

--- a/Sources/Roadmap/RoadmapFeatureViewModel.swift
+++ b/Sources/Roadmap/RoadmapFeatureViewModel.swift
@@ -8,6 +8,7 @@
 import Foundation
 import SwiftUI
 
+@available(macOS 14.0, iOS 17.0, visionOS 1.0, *)
 @MainActor
 @Observable
 final class RoadmapFeatureViewModel {

--- a/Sources/Roadmap/RoadmapView.swift
+++ b/Sources/Roadmap/RoadmapView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+@available(macOS 14.0, iOS 17.0, visionOS 1.0, *)
 public struct RoadmapView<Header: View, Footer: View>: View {
     @State var viewModel: RoadmapViewModel
     let header: Header
@@ -37,7 +38,7 @@ public struct RoadmapView<Header: View, Footer: View>: View {
                 .listStyle(.plain)
                 .conditionalSearchable(if: viewModel.allowSearching, text: $viewModel.searchText)
     }
-    
+
     var featuresList: some View {
         VStack {
             if viewModel.allowsFilterByStatus {
@@ -76,32 +77,35 @@ public struct RoadmapView<Header: View, Footer: View>: View {
     }
 }
 
+@available(macOS 14.0, iOS 17.0, visionOS 1.0, *)
 public extension RoadmapView where Header == EmptyView, Footer == EmptyView {
     init(configuration: RoadmapConfiguration) {
         self.init(viewModel: .init(configuration: configuration), header: EmptyView(), footer: EmptyView(), selectedFilter: RoadmapViewModel.allStatusFilter)
     }
 }
 
+@available(macOS 14.0, iOS 17.0, visionOS 1.0, *)
 public extension RoadmapView where Header: View, Footer == EmptyView {
     init(configuration: RoadmapConfiguration, @ViewBuilder header: () -> Header) {
         self.init(viewModel: .init(configuration: configuration), header: header(), footer: EmptyView(), selectedFilter: RoadmapViewModel.allStatusFilter)
     }
 }
 
+@available(macOS 14.0, iOS 17.0, visionOS 1.0, *)
 public extension RoadmapView where Header == EmptyView, Footer: View {
     init(configuration: RoadmapConfiguration, @ViewBuilder footer: () -> Footer) {
         self.init(viewModel: .init(configuration: configuration), header: EmptyView(), footer: footer(), selectedFilter: RoadmapViewModel.allStatusFilter)
     }
 }
 
+@available(macOS 14.0, iOS 17.0, visionOS 1.0, *)
 public extension RoadmapView where Header: View, Footer: View {
     init(configuration: RoadmapConfiguration, @ViewBuilder header: () -> Header, @ViewBuilder footer: () -> Footer) {
         self.init(viewModel: .init(configuration: configuration), header: header(), footer: footer(), selectedFilter: RoadmapViewModel.allStatusFilter)
     }
 }
 
-struct RoadmapView_Previews: PreviewProvider {
-    static var previews: some View {
-        RoadmapView(configuration: .sampleURL())
-    }
+@available(macOS 14.0, iOS 17.0, visionOS 1.0, *)
+#Preview {
+    RoadmapView(configuration: .sampleURL())
 }

--- a/Sources/Roadmap/RoadmapViewModel.swift
+++ b/Sources/Roadmap/RoadmapViewModel.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+@available(macOS 14.0, iOS 17.0, visionOS 1.0, *)
 @MainActor
 @Observable
 final class RoadmapViewModel {

--- a/Sources/Roadmap/RoadmapVoteButton.swift
+++ b/Sources/Roadmap/RoadmapVoteButton.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+@available(macOS 14.0, iOS 17.0, visionOS 1.0, *)
 struct RoadmapVoteButton: View {
     @State var viewModel: RoadmapFeatureViewModel
     @Environment(\.dynamicTypeSize) private var typeSize


### PR DESCRIPTION
I have a macOS app with **macOS 13+** set as deployment target.
Since I cannot condition `import Roadmap` in my file, I thought to backport `package.json` so that it is generally importable by older deployment targets and condition the views and other structs with `@available(...)` within my app. The downside is that the framework is not available to older environments, but I could link to my website in this rare case.

What do you think?