### PR TITLE
Add Auctorium to the app list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ Yes, please! We would love to invite you to pick up any of the open issues. We'l
 - [Photo Club Waalre](https://apps.apple.com/nl/app/fotogroep-waalre/id1178324330)
 - [Leximio](https://apps.apple.com/app/leximio/id1671844955)
 - [Discretion](https://apps.apple.com/app/discretion/id1635616662)
+- [Auctorium](https://apps.apple.com/app/auctorium/id6756827686)
 
 If you've integrated Roadmap into your app and you want to add it to this list, please make a Pull Request.
 


### PR DESCRIPTION
Added my App Auctorium. 

I am using the Roadmap with CloudKit Backend: https://github.com/AvdLee/Roadmap/pull/100

<img width="1206" height="2622" alt="simulator_screenshot_BC6B1C52-D200-488F-9EFA-F3D7617ECFA7" src="https://github.com/user-attachments/assets/fd897806-d060-4786-8cd3-a9844be81a55" />
